### PR TITLE
Add support for `autoK` and `slippage` in quoter types

### DIFF
--- a/src/api/quoter/quote/quote.ts
+++ b/src/api/quoter/quote/quote.ts
@@ -44,6 +44,8 @@ export class Quote {
 
     public readonly volume: Cost
 
+    public readonly slippage: number
+
     constructor(
         private readonly params: QuoterRequest,
         response: QuoterResponse
@@ -66,6 +68,7 @@ export class Quote {
         this.quoteId = response.quoteId
         this.whitelist = response.whitelist.map((a) => new Address(a))
         this.recommendedPreset = response.recommendedPreset
+        this.slippage = response.autoK
         this.srcEscrowFactory = new Address(response.srcEscrowFactory)
         this.dstEscrowFactory = new Address(response.dstEscrowFactory)
     }

--- a/src/api/quoter/quoter.api.spec.ts
+++ b/src/api/quoter/quoter.api.spec.ts
@@ -32,6 +32,7 @@ describe('Quoter API', () => {
         quoteId: '27d54fa5-9e57-47dc-af27-8ed150a7ca75',
         srcTokenAmount: '100000000000000000',
         dstTokenAmount: '256915982',
+        autoK: 1,
         presets: {
             fast: {
                 auctionDuration: 180,

--- a/src/api/quoter/types.ts
+++ b/src/api/quoter/types.ts
@@ -37,6 +37,7 @@ export type QuoterResponse = {
     timeLocks: TimeLocksRaw
     srcSafetyDeposit: string
     dstSafetyDeposit: string
+    autoK: number
 }
 
 export type TimeLocksRaw = {


### PR DESCRIPTION
Introduced `autoK` to `QuoterConfig` and mapped it to `slippage` in the `Quote` class. This allows handling of slippage data from responses, improving quote processing and accuracy.