### PR TITLE
fix: correct evm2evm order creation

### DIFF
--- a/src/sdk/sdk.spec.ts
+++ b/src/sdk/sdk.spec.ts
@@ -5,7 +5,14 @@ import {
     Web3ProviderConnector
 } from '@1inch/fusion-sdk'
 import {SDK} from './sdk.js'
+import {HashLock} from '../domains/index.js'
 import {NetworkEnum} from '../chains.js'
+import {
+    Quote,
+    PresetEnum,
+    QuoterResponse,
+    QuoterRequest
+} from '../api/quoter/index.js'
 
 function createHttpProviderFake<T>(mock: T): HttpProviderConnector {
     return {
@@ -17,6 +24,8 @@ function createHttpProviderFake<T>(mock: T): HttpProviderConnector {
         })
     }
 }
+
+const url = 'https://test.com'
 
 describe(__filename, () => {
     let web3Provider: Web3Like
@@ -30,8 +39,6 @@ describe(__filename, () => {
     })
 
     it('returns encoded call data to cancel order', async () => {
-        const url = 'https://test.com'
-
         const expected = {
             order: {
                 salt: '45144194282371711345892930501725766861375817078109214409479816083205610767025',
@@ -94,5 +101,143 @@ describe(__filename, () => {
         await expect(promise).rejects.toThrow(
             'Can not get order with the specified orderHash 0x1beee023ab933cf5446c298eadadb61c05705f2156ef5b2db36c160b36f31ce4'
         )
+    })
+
+    it('creates evm->evm order', () => {
+        const params = QuoterRequest.forEVM({
+            srcChain: NetworkEnum.ETHEREUM,
+            dstChain: NetworkEnum.POLYGON,
+            srcTokenAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+            dstTokenAddress: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
+            amount: '100000000000000000',
+            walletAddress: '0x00000000219ab540356cbb839cbe05303d7705fa'
+        })
+
+        const ResponseMock: QuoterResponse = {
+            quoteId: '27d54fa5-9e57-47dc-af27-8ed150a7ca75',
+            srcTokenAmount: '100000000000000000',
+            dstTokenAmount: '256915982',
+            autoK: 1,
+            presets: {
+                fast: {
+                    auctionDuration: 180,
+                    startAuctionIn: 24,
+                    initialRateBump: 84909,
+                    auctionStartAmount: '257797497',
+                    startAmount: '256915967',
+                    auctionEndAmount: '255626994',
+                    exclusiveResolver: null,
+                    costInDstToken: '881530',
+                    points: [
+                        {
+                            delay: 120,
+                            coefficient: 63932
+                        },
+                        {
+                            delay: 60,
+                            coefficient: 34485
+                        }
+                    ],
+                    allowPartialFills: false,
+                    allowMultipleFills: false,
+                    gasCost: {
+                        gasBumpEstimate: 34485,
+                        gasPriceEstimate: '1171'
+                    },
+                    secretsCount: 1
+                },
+                medium: {
+                    auctionDuration: 360,
+                    startAuctionIn: 24,
+                    initialRateBump: 84909,
+                    auctionStartAmount: '257797497',
+                    startAmount: '256915967',
+                    auctionEndAmount: '255626994',
+                    exclusiveResolver: null,
+                    costInDstToken: '881530',
+                    points: [
+                        {
+                            delay: 360,
+                            coefficient: 34485
+                        }
+                    ],
+                    allowPartialFills: false,
+                    allowMultipleFills: false,
+                    gasCost: {
+                        gasBumpEstimate: 34485,
+                        gasPriceEstimate: '1171'
+                    },
+                    secretsCount: 1
+                },
+                slow: {
+                    auctionDuration: 600,
+                    startAuctionIn: 24,
+                    initialRateBump: 84909,
+                    auctionStartAmount: '257797497',
+                    startAmount: '256915967',
+                    auctionEndAmount: '255626994',
+                    exclusiveResolver: null,
+                    costInDstToken: '881530',
+                    points: [
+                        {
+                            delay: 600,
+                            coefficient: 34485
+                        }
+                    ],
+                    allowPartialFills: false,
+                    allowMultipleFills: false,
+                    gasCost: {
+                        gasBumpEstimate: 34485,
+                        gasPriceEstimate: '1171'
+                    },
+                    secretsCount: 1
+                }
+            },
+            timeLocks: {
+                srcWithdrawal: 36,
+                srcPublicWithdrawal: 336,
+                srcCancellation: 492,
+                srcPublicCancellation: 612,
+                dstWithdrawal: 180,
+                dstPublicWithdrawal: 300,
+                dstCancellation: 420
+            },
+            srcEscrowFactory: '0x0000000000000000000000000000000000000000',
+            dstEscrowFactory: '0x0000000000000000000000000000000000000000',
+            srcSafetyDeposit: '141752059440000',
+            dstSafetyDeposit: '20474999822640000',
+            whitelist: ['0x7246999fd1bab15b4ac7d1a23c3abeed63c51b86'],
+            recommendedPreset: PresetEnum.fast,
+            prices: {
+                usd: {
+                    srcToken: '2577.6314',
+                    dstToken: '0.9996849753143391'
+                }
+            },
+            volume: {
+                usd: {
+                    srcToken: '257.76',
+                    dstToken: '257.72'
+                }
+            }
+        }
+
+        const httpProvider = createHttpProviderFake(undefined)
+        const sdk = new SDK({
+            url,
+            httpProvider,
+            blockchainProvider: web3ProviderConnector
+        })
+        const quote = Quote.fromEVMQuote(params, ResponseMock)
+
+        const order = sdk.createOrder(quote, {
+            hashLock: HashLock.fromString(
+                '0xa1195b3d7dcc5e0d82df9e8a61c034d51920b7d5947b4af2330eb43342521f2b'
+            ),
+            secretHashes: [],
+            walletAddress: '0x0000000000000000000000000000000000000000'
+        })
+
+        expect(order).toBeDefined()
     })
 })

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -341,7 +341,7 @@ export class SDK {
         params: OrderParams
     ): SvmCrossChainOrder | EvmCrossChainOrder {
         if (quote.isEvmQuote()) {
-            quote.createEvmOrder({
+            return quote.createEvmOrder({
                 hashLock: params.hashLock,
                 receiver: params.receiver
                     ? EvmAddress.fromString(params.receiver)


### PR DESCRIPTION
## Change Summary
**What does this PR change?**
<!-- Describe the changes in 1-2 sentences -->
Fix `Sdk.createOrder` for evm to evm case. Before fix, order creation failed because of incorrect handle for correct EVM orders without specified `receiver` field

## Testing & Verification
**How was this tested?**
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing (describe steps)
- [ ] Verified on staging
<!-- Provide logs, screenshots, or steps to reproduce -->

## Risk Assessment
**Risk Level:**
- [x] **Low** - Minor changes, no operational impact
- [ ] **Medium** - Moderate changes, limited impact, standard rollback available
- [ ] **High** - Significant changes, potential operational impact, complex rollback

**Risks & Impact**
<!-- Describe any possible risks, such as migrations, downtime, or breaking changes, etc. -->
