### PR TITLE
Add e2e integration test running for pull requests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,48 @@
+name: E2E Integration Tests
+
+# Runs on every PR as a non-blocking check.
+
+on:
+  pull_request:
+
+jobs:
+  e2e:
+    name: Integration / E2E Tests
+    runs-on: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Build contracts
+        run: pnpm build:contracts:evm
+
+      - name: E2E tests
+        env:
+          FORK_URL: ${{ secrets.FORK_URL }}
+        run: pnpm run test:integrationCI

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:integration": "jest -c jest.integration.config.js",
+    "test:integrationCI": "jest -c jest.integration.config.js --maxWorkers=1",
     "changelog:generate": "changelog generate -a",
     "qa:fix": "pnpm build && pnpm format && pnpm lint && pnpm lint:types && pnpm test"
   },


### PR DESCRIPTION
DOPS-1990

## Change Summary
**What does this PR change?**
Add a github action that runs for pull requests executing the integration test.

**Related Issue/Ticket:**
DOPS-1990

## Testing & Verification
**How was this tested?**
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing (describe steps)
- [ ] Verified on staging


## Risk Assessment
**Risk Level:**
- [x] **Low** - Minor changes, no operational impact
- [ ] **Medium** - Moderate changes, limited impact, standard rollback available
- [ ] **High** - Significant changes, potential operational impact, complex rollback

**Risks & Impact**
No risk. Doesn't change any data - simply gives feedback if integration test is running properly.
