### PR TITLE
feat(PT9-763): add Robinhood chain (4663) support

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
   },
   "dependencies": {
     "@1inch/byte-utils": "3.1.7",
-    "@1inch/fusion-sdk": "2.4.8",
-    "@1inch/limit-order-sdk": "5.3.0",
+    "@1inch/fusion-sdk": "2.4.10",
+    "@1inch/limit-order-sdk": "5.3.1",
     "@coral-xyz/anchor": "0.32.1",
     "@openzeppelin/merkle-tree": "1.0.8",
     "@types/bn.js": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/cross-chain-sdk",
-  "version": "2.1.3",
+  "version": "2.1.4-rc.0",
   "description": "Sdk for creating atomic swaps through 1inch",
   "author": "@1inch",
   "module": "./dist/esm/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ packages:
     engines: {node: '>=18.16.0'}
     peerDependencies:
       assert: ^2.0.0
+    peerDependenciesMeta:
+      assert:
+        optional: true
 
   '@1inch/byte-utils@3.1.7':
     resolution: {integrity: sha512-AXS9XWOPXnTYFYozc10fYE3PnplD9RmCzO57U4vzxzGQ0zgdeoTfYe8hXej/NctYJFcTL3PzyC0HZn2sZ7IWbA==}
@@ -196,6 +199,11 @@ packages:
     peerDependencies:
       assert: ^2.0.0
       axios: '>=1 <2'
+    peerDependenciesMeta:
+      assert:
+        optional: true
+      axios:
+        optional: true
 
   '@1inch/limit-order-sdk@5.3.1':
     resolution: {integrity: sha512-STEKaWd+/0xcy13RYsASUdkGI79IflMIZWzakaesy1wHjaPMnkXuqHm0wS0WOUYIlqZK0CwtcCLXK+NO7ZBQGw==, tarball: https://npm.pkg.github.com/download/@1inch/limit-order-sdk/5.3.1/61d59d42f51abcf9a77e69b02756ef1a5aeb1df0}
@@ -203,6 +211,11 @@ packages:
     peerDependencies:
       assert: ^2.0.0
       axios: '>=1 <2'
+    peerDependenciesMeta:
+      assert:
+        optional: true
+      axios:
+        optional: true
 
   '@1inch/tsconfig@1.0.12':
     resolution: {integrity: sha512-yhYczGGHbBUyS5PrXrZXRLB3L+AkXSvr1xbSr04FQtyfJgCoHALvgh8kVijjvPkcFpjLHWrfZ/SB7CArK2e2yg==}
@@ -3751,7 +3764,7 @@ packages:
 snapshots:
 
   '@1inch/byte-utils@3.0.0(assert@2.1.0)':
-    dependencies:
+    optionalDependencies:
       assert: 2.1.0
 
   '@1inch/byte-utils@3.1.7(assert@2.1.0)':
@@ -3778,11 +3791,12 @@ snapshots:
     dependencies:
       '@1inch/byte-utils': 3.1.7(assert@2.1.0)
       '@1inch/limit-order-sdk': 5.3.1(assert@2.1.0)(axios@1.18.1)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      assert: 2.1.0
-      axios: 1.18.1
       ethers: 6.16.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       tslib: 2.8.1
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
+      assert: 2.1.0
+      axios: 1.18.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -3790,9 +3804,10 @@ snapshots:
   '@1inch/limit-order-sdk@5.3.1(assert@2.1.0)(axios@1.18.1)(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@1inch/byte-utils': 3.0.0(assert@2.1.0)
+      ethers: 6.16.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
       assert: 2.1.0
       axios: 1.18.1
-      ethers: 6.16.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,11 +22,11 @@ importers:
         specifier: 3.1.7
         version: 3.1.7(assert@2.1.0)
       '@1inch/fusion-sdk':
-        specifier: 2.4.8
-        version: 2.4.8(assert@2.1.0)(axios@1.18.1)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        specifier: 2.4.10
+        version: 2.4.10(assert@2.1.0)(axios@1.18.1)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@1inch/limit-order-sdk':
-        specifier: 5.3.0
-        version: 5.3.0(assert@2.1.0)(axios@1.18.1)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        specifier: 5.3.1
+        version: 5.3.1(assert@2.1.0)(axios@1.18.1)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@coral-xyz/anchor':
         specifier: 0.32.1
         version: 0.32.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -161,13 +161,10 @@ importers:
 packages:
 
   '@1inch/byte-utils@3.0.0':
-    resolution: {integrity: sha512-CuX4E0z/pzo9hKGzFsMi3vPVgHRRh14ZwNEZ5TY1svnKF8PjxWx3t0CjXCW4dyqKGe6TKAzgYqzzxrMrWPDy5Q==}
+    resolution: {integrity: sha512-CuX4E0z/pzo9hKGzFsMi3vPVgHRRh14ZwNEZ5TY1svnKF8PjxWx3t0CjXCW4dyqKGe6TKAzgYqzzxrMrWPDy5Q==, tarball: https://npm.pkg.github.com/download/@1inch/byte-utils/3.0.0/1c573a3e72586540ea6f542099cd18da978118df}
     engines: {node: '>=18.16.0'}
     peerDependencies:
       assert: ^2.0.0
-    peerDependenciesMeta:
-      assert:
-        optional: true
 
   '@1inch/byte-utils@3.1.7':
     resolution: {integrity: sha512-AXS9XWOPXnTYFYozc10fYE3PnplD9RmCzO57U4vzxzGQ0zgdeoTfYe8hXej/NctYJFcTL3PzyC0HZn2sZ7IWbA==}
@@ -194,28 +191,18 @@ packages:
       typescript: ^5.5.2 || ^6.0.0
       typescript-eslint: ^8.0.0
 
-  '@1inch/fusion-sdk@2.4.8':
-    resolution: {integrity: sha512-FNrWhqCK9F9+i4w+TwwrrAgCCGgan7RmwcpXOFL69BSjAlCYzeA8tR14NRXaq9gyTZGiubry0sXQHbddNNElEA==}
+  '@1inch/fusion-sdk@2.4.10':
+    resolution: {integrity: sha512-zGRKAfHQKKf0zjuqq11QC7shh1PCnwfFJ7g8PJZqT2vheqvveERRkf4I0sCLitPoPDK91xb4+wR3clmEV0HuQw==, tarball: https://npm.pkg.github.com/download/@1inch/fusion-sdk/2.4.10/73763062a7ad0be482fe78200b9a62cddb8ff6a7}
     peerDependencies:
       assert: ^2.0.0
       axios: '>=1 <2'
-    peerDependenciesMeta:
-      assert:
-        optional: true
-      axios:
-        optional: true
 
-  '@1inch/limit-order-sdk@5.3.0':
-    resolution: {integrity: sha512-k32+L3o1ZoxE3KHVNGzxuLSWCpGhciF7bzmD5FdIyzRwO2JpVFJheKBH+bKZ+BjXrVCi9HAVVT5tGoLqJrtO+g==}
+  '@1inch/limit-order-sdk@5.3.1':
+    resolution: {integrity: sha512-STEKaWd+/0xcy13RYsASUdkGI79IflMIZWzakaesy1wHjaPMnkXuqHm0wS0WOUYIlqZK0CwtcCLXK+NO7ZBQGw==, tarball: https://npm.pkg.github.com/download/@1inch/limit-order-sdk/5.3.1/61d59d42f51abcf9a77e69b02756ef1a5aeb1df0}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       assert: ^2.0.0
       axios: '>=1 <2'
-    peerDependenciesMeta:
-      assert:
-        optional: true
-      axios:
-        optional: true
 
   '@1inch/tsconfig@1.0.12':
     resolution: {integrity: sha512-yhYczGGHbBUyS5PrXrZXRLB3L+AkXSvr1xbSr04FQtyfJgCoHALvgh8kVijjvPkcFpjLHWrfZ/SB7CArK2e2yg==}
@@ -1008,28 +995,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.11.24':
     resolution: {integrity: sha512-ypXLIdszRo0re7PNNaXN0+2lD454G8l9LPK/rbfRXnhLWDBPURxzKlLlU/YGd2zP98wPcVooMmegRSNOKfvErw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.11.24':
     resolution: {integrity: sha512-IM7d+STVZD48zxcgo69L0yYptfhaaE9cMZ+9OoMxirNafhKKXwoZuufol1+alEFKc+Wbwp+aUPe/DeWC/Lh3dg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.11.24':
     resolution: {integrity: sha512-DZByJaMVzSfjQKKQn3cqSeqwy6lpMaQDQQ4HPlch9FWtDx/dLcpdIhxssqZXcR2rhaQVIaRQsCqwV6orSDGAGw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.11.24':
     resolution: {integrity: sha512-Q64Ytn23y9aVDKN5iryFi8mRgyHw3/kyjTjT4qFCa8AEb5sGUuSj//AUZ6c0J7hQKMHlg9do5Etvoe61V98/JQ==}
@@ -1322,49 +1305,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2887,14 +2862,12 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   litesvm-linux-x64-musl@0.2.0:
     resolution: {integrity: sha512-9vAYFIicGjZIlwoCBii6yJmfIUVS4cdF0CxoAL+DGexTBLECk+Tr+WEFEXsvsYe4s81jxP04TTiUnasj/EaIcw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   litesvm@0.2.0:
     resolution: {integrity: sha512-75+ZMkSFY5ynI3S+vCMnZv1wcILg5iNEj21B+XE/G3/P2dfTPj+rbdNM1q3eLFdlnXdewhiB4BLypKsBnQTSOw==}
@@ -3778,7 +3751,7 @@ packages:
 snapshots:
 
   '@1inch/byte-utils@3.0.0(assert@2.1.0)':
-    optionalDependencies:
+    dependencies:
       assert: 2.1.0
 
   '@1inch/byte-utils@3.1.7(assert@2.1.0)':
@@ -3801,27 +3774,25 @@ snapshots:
       typescript: 5.9.3
       typescript-eslint: 8.58.2(eslint@9.39.3)(typescript@5.9.3)
 
-  '@1inch/fusion-sdk@2.4.8(assert@2.1.0)(axios@1.18.1)(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@1inch/fusion-sdk@2.4.10(assert@2.1.0)(axios@1.18.1)(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@1inch/byte-utils': 3.1.7(assert@2.1.0)
-      '@1inch/limit-order-sdk': 5.3.0(assert@2.1.0)(axios@1.18.1)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@1inch/limit-order-sdk': 5.3.1(assert@2.1.0)(axios@1.18.1)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      assert: 2.1.0
+      axios: 1.18.1
       ethers: 6.16.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       tslib: 2.8.1
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-    optionalDependencies:
-      assert: 2.1.0
-      axios: 1.18.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@1inch/limit-order-sdk@5.3.0(assert@2.1.0)(axios@1.18.1)(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@1inch/limit-order-sdk@5.3.1(assert@2.1.0)(axios@1.18.1)(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@1inch/byte-utils': 3.0.0(assert@2.1.0)
-      ethers: 6.16.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-    optionalDependencies:
       assert: 2.1.0
       axios: 1.18.1
+      ethers: 6.16.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,7 +161,7 @@ importers:
 packages:
 
   '@1inch/byte-utils@3.0.0':
-    resolution: {integrity: sha512-CuX4E0z/pzo9hKGzFsMi3vPVgHRRh14ZwNEZ5TY1svnKF8PjxWx3t0CjXCW4dyqKGe6TKAzgYqzzxrMrWPDy5Q==, tarball: https://npm.pkg.github.com/download/@1inch/byte-utils/3.0.0/1c573a3e72586540ea6f542099cd18da978118df}
+    resolution: {integrity: sha512-CuX4E0z/pzo9hKGzFsMi3vPVgHRRh14ZwNEZ5TY1svnKF8PjxWx3t0CjXCW4dyqKGe6TKAzgYqzzxrMrWPDy5Q==}
     engines: {node: '>=18.16.0'}
     peerDependencies:
       assert: ^2.0.0
@@ -195,7 +195,7 @@ packages:
       typescript-eslint: ^8.0.0
 
   '@1inch/fusion-sdk@2.4.10':
-    resolution: {integrity: sha512-zGRKAfHQKKf0zjuqq11QC7shh1PCnwfFJ7g8PJZqT2vheqvveERRkf4I0sCLitPoPDK91xb4+wR3clmEV0HuQw==, tarball: https://npm.pkg.github.com/download/@1inch/fusion-sdk/2.4.10/73763062a7ad0be482fe78200b9a62cddb8ff6a7}
+    resolution: {integrity: sha512-zGRKAfHQKKf0zjuqq11QC7shh1PCnwfFJ7g8PJZqT2vheqvveERRkf4I0sCLitPoPDK91xb4+wR3clmEV0HuQw==}
     peerDependencies:
       assert: ^2.0.0
       axios: '>=1 <2'
@@ -206,7 +206,7 @@ packages:
         optional: true
 
   '@1inch/limit-order-sdk@5.3.1':
-    resolution: {integrity: sha512-STEKaWd+/0xcy13RYsASUdkGI79IflMIZWzakaesy1wHjaPMnkXuqHm0wS0WOUYIlqZK0CwtcCLXK+NO7ZBQGw==, tarball: https://npm.pkg.github.com/download/@1inch/limit-order-sdk/5.3.1/61d59d42f51abcf9a77e69b02756ef1a5aeb1df0}
+    resolution: {integrity: sha512-STEKaWd+/0xcy13RYsASUdkGI79IflMIZWzakaesy1wHjaPMnkXuqHm0wS0WOUYIlqZK0CwtcCLXK+NO7ZBQGw==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       assert: ^2.0.0

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -14,6 +14,7 @@ export enum NetworkEnum {
     LINEA = 59144,
     SONIC = 146,
     UNICHAIN = 130,
+    ROBINHOOD = 4663,
     SOLANA = 501
 }
 
@@ -30,6 +31,7 @@ export const SupportedChains = [
     NetworkEnum.LINEA,
     NetworkEnum.SONIC,
     NetworkEnum.UNICHAIN,
+    NetworkEnum.ROBINHOOD,
     NetworkEnum.SOLANA
 ] as const
 

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -21,7 +21,9 @@ export const TRUE_ERC20 = {
     [NetworkEnum.ZKSYNC]: ZKTrueERC20,
     [NetworkEnum.LINEA]: TrueERC20,
     [NetworkEnum.SONIC]: TrueERC20,
-    [NetworkEnum.UNICHAIN]: TrueERC20
+    [NetworkEnum.UNICHAIN]: TrueERC20,
+    // TODO(PT9-763): not deployed on Robinhood yet, verify after deployment
+    [NetworkEnum.ROBINHOOD]: TrueERC20
 }
 
 const ESCROW_FACTORY_ADDRESS = EvmAddress.fromString(
@@ -56,7 +58,9 @@ export const ESCROW_SRC_IMPLEMENTATION = {
     [NetworkEnum.ZKSYNC]: ESCROW_ZK_SRC_IMPLEMENTATION_ADDRESS,
     [NetworkEnum.LINEA]: ESCROW_SRC_IMPLEMENTATION_ADDRESS,
     [NetworkEnum.SONIC]: ESCROW_SRC_IMPLEMENTATION_ADDRESS,
-    [NetworkEnum.UNICHAIN]: ESCROW_SRC_IMPLEMENTATION_ADDRESS
+    [NetworkEnum.UNICHAIN]: ESCROW_SRC_IMPLEMENTATION_ADDRESS,
+    // TODO(PT9-763): not deployed on Robinhood yet, verify after deployment
+    [NetworkEnum.ROBINHOOD]: ESCROW_SRC_IMPLEMENTATION_ADDRESS
 }
 
 export const ESCROW_DST_IMPLEMENTATION = {
@@ -72,7 +76,9 @@ export const ESCROW_DST_IMPLEMENTATION = {
     [NetworkEnum.ZKSYNC]: ESCROW_ZK_DST_IMPLEMENTATION_ADDRESS,
     [NetworkEnum.LINEA]: ESCROW_DST_IMPLEMENTATION_ADDRESS,
     [NetworkEnum.SONIC]: ESCROW_DST_IMPLEMENTATION_ADDRESS,
-    [NetworkEnum.UNICHAIN]: ESCROW_DST_IMPLEMENTATION_ADDRESS
+    [NetworkEnum.UNICHAIN]: ESCROW_DST_IMPLEMENTATION_ADDRESS,
+    // TODO(PT9-763): not deployed on Robinhood yet, verify after deployment
+    [NetworkEnum.ROBINHOOD]: ESCROW_DST_IMPLEMENTATION_ADDRESS
 }
 
 export const ESCROW_FACTORY = {
@@ -88,5 +94,7 @@ export const ESCROW_FACTORY = {
     [NetworkEnum.ZKSYNC]: ESCROW_ZK_FACTORY_ADDRESS,
     [NetworkEnum.LINEA]: ESCROW_FACTORY_ADDRESS,
     [NetworkEnum.SONIC]: ESCROW_FACTORY_ADDRESS,
-    [NetworkEnum.UNICHAIN]: ESCROW_FACTORY_ADDRESS
+    [NetworkEnum.UNICHAIN]: ESCROW_FACTORY_ADDRESS,
+    // TODO(PT9-763): not deployed on Robinhood yet, verify after deployment
+    [NetworkEnum.ROBINHOOD]: ESCROW_FACTORY_ADDRESS
 }

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -7,6 +7,10 @@ const TrueERC20 = EvmAddress.fromString(
 const ZKTrueERC20 = EvmAddress.fromString(
     '0xd66097c27eb8dee404bac235737932260edc6f3b'
 )
+// Robinhood chain uses its own CREATE3 deployer, so addresses differ from other chains
+const RobinhoodTrueERC20 = EvmAddress.fromString(
+    '0x40c0b7e8018cca1eb8d913b75b1b20cfd89b8d5b'
+)
 
 export const TRUE_ERC20 = {
     [NetworkEnum.ETHEREUM]: TrueERC20,
@@ -22,8 +26,7 @@ export const TRUE_ERC20 = {
     [NetworkEnum.LINEA]: TrueERC20,
     [NetworkEnum.SONIC]: TrueERC20,
     [NetworkEnum.UNICHAIN]: TrueERC20,
-    // TODO(PT9-763): not deployed on Robinhood yet, verify after deployment
-    [NetworkEnum.ROBINHOOD]: TrueERC20
+    [NetworkEnum.ROBINHOOD]: RobinhoodTrueERC20
 }
 
 const ESCROW_FACTORY_ADDRESS = EvmAddress.fromString(
@@ -44,6 +47,16 @@ const ESCROW_DST_IMPLEMENTATION_ADDRESS = EvmAddress.fromString(
 const ESCROW_ZK_DST_IMPLEMENTATION_ADDRESS = EvmAddress.fromString(
     '0x07d3d5e598cc23bfee9884b1e342ddaecd88dead'
 )
+// Robinhood chain uses its own CREATE3 deployer, so addresses differ from other chains
+const ESCROW_RH_FACTORY_ADDRESS = EvmAddress.fromString(
+    '0x50d26ea1e2460b3a42ff47466b955fc6bd906013'
+)
+const ESCROW_RH_SRC_IMPLEMENTATION_ADDRESS = EvmAddress.fromString(
+    '0xb540a42ca356f30307439b60647b5704d57f45ee'
+)
+const ESCROW_RH_DST_IMPLEMENTATION_ADDRESS = EvmAddress.fromString(
+    '0x3875faf11ccef1dca35d190bc41cd47895dc18b2'
+)
 
 export const ESCROW_SRC_IMPLEMENTATION = {
     [NetworkEnum.ETHEREUM]: ESCROW_SRC_IMPLEMENTATION_ADDRESS,
@@ -59,8 +72,7 @@ export const ESCROW_SRC_IMPLEMENTATION = {
     [NetworkEnum.LINEA]: ESCROW_SRC_IMPLEMENTATION_ADDRESS,
     [NetworkEnum.SONIC]: ESCROW_SRC_IMPLEMENTATION_ADDRESS,
     [NetworkEnum.UNICHAIN]: ESCROW_SRC_IMPLEMENTATION_ADDRESS,
-    // TODO(PT9-763): not deployed on Robinhood yet, verify after deployment
-    [NetworkEnum.ROBINHOOD]: ESCROW_SRC_IMPLEMENTATION_ADDRESS
+    [NetworkEnum.ROBINHOOD]: ESCROW_RH_SRC_IMPLEMENTATION_ADDRESS
 }
 
 export const ESCROW_DST_IMPLEMENTATION = {
@@ -77,8 +89,7 @@ export const ESCROW_DST_IMPLEMENTATION = {
     [NetworkEnum.LINEA]: ESCROW_DST_IMPLEMENTATION_ADDRESS,
     [NetworkEnum.SONIC]: ESCROW_DST_IMPLEMENTATION_ADDRESS,
     [NetworkEnum.UNICHAIN]: ESCROW_DST_IMPLEMENTATION_ADDRESS,
-    // TODO(PT9-763): not deployed on Robinhood yet, verify after deployment
-    [NetworkEnum.ROBINHOOD]: ESCROW_DST_IMPLEMENTATION_ADDRESS
+    [NetworkEnum.ROBINHOOD]: ESCROW_RH_DST_IMPLEMENTATION_ADDRESS
 }
 
 export const ESCROW_FACTORY = {
@@ -95,6 +106,5 @@ export const ESCROW_FACTORY = {
     [NetworkEnum.LINEA]: ESCROW_FACTORY_ADDRESS,
     [NetworkEnum.SONIC]: ESCROW_FACTORY_ADDRESS,
     [NetworkEnum.UNICHAIN]: ESCROW_FACTORY_ADDRESS,
-    // TODO(PT9-763): not deployed on Robinhood yet, verify after deployment
-    [NetworkEnum.ROBINHOOD]: ESCROW_FACTORY_ADDRESS
+    [NetworkEnum.ROBINHOOD]: ESCROW_RH_FACTORY_ADDRESS
 }


### PR DESCRIPTION
## Summary

- Add `ROBINHOOD = 4663` to `NetworkEnum` and `SupportedChains`
- Add Robinhood entries to `TRUE_ERC20`, `ESCROW_FACTORY`, `ESCROW_SRC_IMPLEMENTATION`, `ESCROW_DST_IMPLEMENTATION` (standard CREATE3 addresses)
- Bump `@1inch/fusion-sdk` 2.4.8 → 2.4.10 and `@1inch/limit-order-sdk` 5.3.0 → 5.3.1 (carry the Robinhood custom LOP `0x5a705d...89c7` and WETH `0x0bd7d3...ad73`)

Mirrors the fusion-sdk v2.4.10 Robinhood change (#175).

## Release gate

Escrow contracts are **not yet deployed** on Robinhood (marked with `TODO(PT9-763)` in `deployments.ts`). Do not publish until the four addresses have code on-chain:
`0x03a25b...7efa` (factory), `0x30476b...0ca0` (src impl), `0x5cd822...c73a` (dst impl), `0xda0000...66f8` (TrueERC20).

## Consumer notes

- Widening `SupportedChains` intentionally breaks downstream exhaustive chain mappings until they add the ROBINHOOD arm
- Consumers must ship their `chain_4663` config in the same deploy as this SDK bump
- Suggested release: 2.2.0

## Test plan

- [x] `pnpm lint`, `pnpm lint:types`, `pnpm test` (23 suites, 133 tests) — green
- [ ] Post-deployment: verify the four escrow addresses on Robinhood Blockscout before npm publish