### PR TITLE
ci: add auto-updating test coverage badge to README

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -1,0 +1,59 @@
+name: Coverage badge
+
+on:
+  push:
+    branches:
+      - master
+
+  # Runs on PRs only when the coverage tooling itself changes, to validate it.
+  pull_request:
+    paths:
+      - '.github/workflows/coverage-badge.yml'
+      - 'scripts/generate-coverage-badge.mjs'
+
+  workflow_dispatch:
+
+concurrency:
+  group: coverage-badge-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coverage-badge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Run unit tests with coverage
+        run: pnpm test:cov
+
+      - name: Generate coverage badge
+        run: node scripts/generate-coverage-badge.mjs
+
+      # The badge lives on the orphan `badges` branch so the README can embed it
+      # via https://github.com/${{ github.repository }}/raw/badges/coverage-badge.svg
+      - name: Publish badge to badges branch
+        if: github.event_name != 'pull_request'
+        run: |
+          cd coverage-badge
+          git init -q -b badges
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add coverage-badge.svg
+          git commit -q -m "chore: update coverage badge for ${GITHUB_SHA}"
+          git push -q --force "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" badges

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Cross Chain SDK
 Sdk for creating atomic swaps through 1inch
 
+[![Test coverage](https://github.com/1inch/cross-chain-sdk/raw/badges/coverage-badge.svg)](https://github.com/1inch/cross-chain-sdk/actions/workflows/coverage-badge.yml)
+
 ## Resources
 - [Dev portal](https://portal.1inch.dev/documentation/apis/swap/fusion-plus/introduction)
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,8 @@
 module.exports = {
     clearMocks: true,
     collectCoverageFrom: ['**/*.(t|j)s'],
-    coverageDirectory: 'coverage',
+    // relative to rootDir ('src'), so reports land in <repo>/coverage (gitignored)
+    coverageDirectory: '../coverage',
     coveragePathIgnorePatterns: ['/node_modules/', 'dist', 'src/index.ts'],
     coverageProvider: 'v8',
     coverageReporters: ['json-summary', 'lcov'],

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "lint": "eslint  \"{src,apps,libs,test}/**/*.ts\" --fix",
     "lint:types": "tsc --noEmit",
     "test": "jest",
+    "test:cov": "jest --coverage --coverageReporters=text-summary --coverageReporters=json-summary",
     "test:watch": "jest --watch",
     "test:integration": "jest -c jest.integration.config.js",
     "changelog:generate": "changelog generate -a",

--- a/scripts/generate-coverage-badge.mjs
+++ b/scripts/generate-coverage-badge.mjs
@@ -1,0 +1,75 @@
+/**
+ * Generates a shields.io-style SVG coverage badge from Jest's
+ * coverage/coverage-summary.json (produced by the json-summary reporter).
+ *
+ * Usage: node scripts/generate-coverage-badge.mjs [output-dir]
+ *
+ * Writes <output-dir>/coverage-badge.svg (default output dir: coverage-badge).
+ * The badge is published to the orphan `badges` branch by the
+ * .github/workflows/coverage-badge.yml workflow and referenced from the README.
+ */
+import {existsSync, mkdirSync, readFileSync, writeFileSync} from 'node:fs'
+import {join} from 'node:path'
+
+const SUMMARY_PATH = 'coverage/coverage-summary.json'
+const OUTPUT_DIR = process.argv[2] ?? 'coverage-badge'
+
+function color(pct) {
+    if (pct >= 90) return '#4c1' // brightgreen
+    if (pct >= 80) return '#97ca00' // green
+    if (pct >= 70) return '#a4a61d' // yellowgreen
+    if (pct >= 60) return '#dfb317' // yellow
+    if (pct >= 50) return '#fe7d37' // orange
+    return '#e05d44' // red
+}
+
+// Approximate Verdana 11px text width, good enough for a short badge label
+function textWidth(text) {
+    return Math.round([...text].reduce((width, char) => width + (/[%.]/.test(char) ? 6.5 : 7.5), 0))
+}
+
+function renderBadge(label, value, valueColor) {
+    const labelWidth = textWidth(label) + 10
+    const valueWidth = textWidth(value) + 10
+    const width = labelWidth + valueWidth
+
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="20" role="img" aria-label="${label}: ${value}">
+  <title>${label}: ${value}</title>
+  <linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>
+  <clipPath id="r"><rect width="${width}" height="20" rx="3" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="${labelWidth}" height="20" fill="#555"/>
+    <rect x="${labelWidth}" width="${valueWidth}" height="20" fill="${valueColor}"/>
+    <rect width="${width}" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="110" text-rendering="geometricPrecision">
+    <text x="${labelWidth * 5}" y="150" transform="scale(.1)" fill="#010101" fill-opacity=".3" textLength="${(labelWidth - 10) * 10}">${label}</text>
+    <text x="${labelWidth * 5}" y="140" transform="scale(.1)" textLength="${(labelWidth - 10) * 10}">${label}</text>
+    <text x="${(labelWidth + valueWidth / 2) * 10}" y="150" transform="scale(.1)" fill="#010101" fill-opacity=".3" textLength="${(valueWidth - 10) * 10}">${value}</text>
+    <text x="${(labelWidth + valueWidth / 2) * 10}" y="140" transform="scale(.1)" textLength="${(valueWidth - 10) * 10}">${value}</text>
+  </g>
+</svg>
+`
+}
+
+let value = 'unknown'
+let valueColor = '#9f9f9f' // lightgrey
+
+if (existsSync(SUMMARY_PATH)) {
+    const {total} = JSON.parse(readFileSync(SUMMARY_PATH, 'utf8'))
+
+    if (total.lines.total > 0) {
+        const pct = total.lines.pct
+        value = `${Math.round(pct * 10) / 10}%`
+        valueColor = color(pct)
+    }
+}
+
+mkdirSync(OUTPUT_DIR, {recursive: true})
+writeFileSync(join(OUTPUT_DIR, 'coverage-badge.svg'), renderBadge('coverage', value, valueColor))
+
+console.log(`Total line coverage: ${value}`)
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+    writeFileSync(process.env.GITHUB_STEP_SUMMARY, `**Total line coverage:** ${value}\n`, {flag: 'a'})
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an auto-updating test coverage badge to the README, computed entirely inside GitHub Actions (no third-party services). Same approach as [1inch/cross-chain#428](https://github.com/1inch/cross-chain/pull/428).

- **README**: embeds the badge at the top, served from the orphan `badges` branch via `https://github.com/1inch/cross-chain-sdk/raw/badges/coverage-badge.svg`.
- **`.github/workflows/coverage-badge.yml`**: on every push to `master` (and manual dispatch) it installs dependencies, runs `pnpm test:cov`, renders the badge SVG, and force-pushes it to the `badges` branch. On PRs it runs only when the coverage tooling itself changes, and skips publishing. Runner/pnpm/node setup mirrors `pr-check.yml` (ubuntu-latest, pnpm 10, node 20).
- **`scripts/generate-coverage-badge.mjs`**: renders a shields.io-style SVG (total line coverage, color-coded) from Jest's `json-summary` reporter output.
- **`package.json`**: adds a `test:cov` script (`jest --coverage` with `text-summary` + `json-summary` reporters).
- **`jest.config.js`**: coverage reports now land in `<repo>/coverage` (gitignored) instead of `src/coverage` — `coverageDirectory` is resolved relative to `rootDir` (`src`), so the previous value wrote inside the source tree.

The `badges` branch has been seeded with the real current value (**88.2%** line coverage), so the README renders immediately; the workflow refreshes it on every subsequent push to `master`.

## Verification

- The `pull_request` run of the `Coverage badge` workflow on this PR passed (23 suites / 133 tests, total line coverage 88.2%).
- The `PR validation` failure is unrelated: npm retired its legacy audit endpoint (HTTP 410 from `registry.npmjs.org/-/npm/v1/security/audits`), which breaks the `pnpm audit` step on every branch as of today — the same step passed on other PRs as recently as July 14.

## Notes

- Coverage reflects the unit test suite (`jest.config.js`); integration tests are not included.
- The publish step relies on the workflow `GITHUB_TOKEN` having `contents: write` (declared in the workflow). If the org enforces read-only workflow tokens, the push step will fail and a PAT/deploy key would be needed instead.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c61fe14-4348-4f02-9ad7-2d6a28615f5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c61fe14-4348-4f02-9ad7-2d6a28615f5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

