### PR TITLE
fix: Robinhood chain LOP verifying contract and wrapped native token map

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "dependencies": {
         "@1inch/byte-utils": "3.1.0",
         "@1inch/fusion-sdk": "2.1.12-rc.1",
-        "@1inch/limit-order-sdk": "5.2.2",
+        "@1inch/limit-order-sdk": "5.3.1",
         "@coral-xyz/anchor": "0.31.1",
         "@openzeppelin/merkle-tree": "1.0.7",
         "@types/bn.js": "5.2.0",
@@ -108,6 +108,7 @@
     },
     "pnpm": {
         "overrides": {
+            "@1inch/limit-order-sdk@<5.3.1": "5.3.1",
             "cross-spawn@>=7.0.0 <7.0.5": ">=7.0.5",
             "elliptic@<=6.6.0": ">=6.6.1",
             "protobufjs@<7.6.1": ">=7.6.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     },
     "dependencies": {
         "@1inch/byte-utils": "3.1.0",
-        "@1inch/fusion-sdk": "2.1.12-rc.1",
+        "@1inch/fusion-sdk": "2.1.13-rc.0",
         "@1inch/limit-order-sdk": "5.3.1",
         "@coral-xyz/anchor": "0.31.1",
         "@openzeppelin/merkle-tree": "1.0.7",
@@ -108,7 +108,6 @@
     },
     "pnpm": {
         "overrides": {
-            "@1inch/limit-order-sdk@<5.3.1": "5.3.1",
             "cross-spawn@>=7.0.0 <7.0.5": ">=7.0.5",
             "elliptic@<=6.6.0": ">=6.6.1",
             "protobufjs@<7.6.1": ">=7.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@1inch/limit-order-sdk@<5.3.1': 5.3.1
   cross-spawn@>=7.0.0 <7.0.5: '>=7.0.5'
   elliptic@<=6.6.0: '>=6.6.1'
   protobufjs@<7.6.1: '>=7.6.1'
@@ -33,8 +34,8 @@ importers:
         specifier: 2.1.12-rc.1
         version: 2.1.12-rc.1(assert@2.1.0)(axios@1.16.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@1inch/limit-order-sdk':
-        specifier: 5.2.2
-        version: 5.2.2(assert@2.1.0)(axios@1.16.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+        specifier: 5.3.1
+        version: 5.3.1(assert@2.1.0)(axios@1.16.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@coral-xyz/anchor':
         specifier: 0.31.1
         version: 0.31.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -219,8 +220,8 @@ packages:
       axios:
         optional: true
 
-  '@1inch/limit-order-sdk@5.2.2':
-    resolution: {integrity: sha512-zUvo4kpc1hCUx2znUUhYrRl2vdAsao6ubJIUngtM5Kpz07zHKLIIS/FarY2AktZeHQiUTotTrj7C1h9HjCQYow==}
+  '@1inch/limit-order-sdk@5.3.1':
+    resolution: {integrity: sha512-STEKaWd+/0xcy13RYsASUdkGI79IflMIZWzakaesy1wHjaPMnkXuqHm0wS0WOUYIlqZK0CwtcCLXK+NO7ZBQGw==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       assert: ^2.0.0
@@ -900,24 +901,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.11.24':
     resolution: {integrity: sha512-ypXLIdszRo0re7PNNaXN0+2lD454G8l9LPK/rbfRXnhLWDBPURxzKlLlU/YGd2zP98wPcVooMmegRSNOKfvErw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.11.24':
     resolution: {integrity: sha512-IM7d+STVZD48zxcgo69L0yYptfhaaE9cMZ+9OoMxirNafhKKXwoZuufol1+alEFKc+Wbwp+aUPe/DeWC/Lh3dg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.11.24':
     resolution: {integrity: sha512-DZByJaMVzSfjQKKQn3cqSeqwy6lpMaQDQQ4HPlch9FWtDx/dLcpdIhxssqZXcR2rhaQVIaRQsCqwV6orSDGAGw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.11.24':
     resolution: {integrity: sha512-Q64Ytn23y9aVDKN5iryFi8mRgyHw3/kyjTjT4qFCa8AEb5sGUuSj//AUZ6c0J7hQKMHlg9do5Etvoe61V98/JQ==}
@@ -1185,41 +1190,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2000,8 +2013,8 @@ packages:
     resolution: {integrity: sha512-hdJ2HOxg/xx97Lm9HdCWk949BfYqYWpyw4//78SiwOLgASyfrNszfMUNB2joKjvGUdwhHfaiMMFFwacVVoLR9A==}
     engines: {node: '>=14.0.0'}
 
-  ethers@6.13.5:
-    resolution: {integrity: sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ==}
+  ethers@6.16.0:
+    resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
     engines: {node: '>=14.0.0'}
 
   event-target-shim@5.0.1:
@@ -2724,12 +2737,14 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   litesvm-linux-x64-musl@0.2.0:
     resolution: {integrity: sha512-9vAYFIicGjZIlwoCBii6yJmfIUVS4cdF0CxoAL+DGexTBLECk+Tr+WEFEXsvsYe4s81jxP04TTiUnasj/EaIcw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   litesvm@0.2.0:
     resolution: {integrity: sha512-75+ZMkSFY5ynI3S+vCMnZv1wcILg5iNEj21B+XE/G3/P2dfTPj+rbdNM1q3eLFdlnXdewhiB4BLypKsBnQTSOw==}
@@ -3609,7 +3624,7 @@ snapshots:
   '@1inch/fusion-sdk@2.1.12-rc.1(assert@2.1.0)(axios@1.16.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
     dependencies:
       '@1inch/byte-utils': 3.1.0(assert@2.1.0)
-      '@1inch/limit-order-sdk': 5.2.2(assert@2.1.0)(axios@1.16.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@1inch/limit-order-sdk': 5.3.1(assert@2.1.0)(axios@1.16.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       ethers: 6.13.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       tslib: 2.6.3
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -3620,10 +3635,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@1inch/limit-order-sdk@5.2.2(assert@2.1.0)(axios@1.16.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+  '@1inch/limit-order-sdk@5.3.1(assert@2.1.0)(axios@1.16.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
     dependencies:
       '@1inch/byte-utils': 3.0.0(assert@2.1.0)
-      ethers: 6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ethers: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       assert: 2.1.0
       axios: 1.16.0
@@ -5837,7 +5852,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  ethers@6.13.5(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+  ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       '@adraffy/ens-normalize': 1.10.1
       '@noble/curves': 1.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@1inch/limit-order-sdk@<5.3.1': 5.3.1
   cross-spawn@>=7.0.0 <7.0.5: '>=7.0.5'
   elliptic@<=6.6.0: '>=6.6.1'
   protobufjs@<7.6.1: '>=7.6.1'
@@ -31,8 +30,8 @@ importers:
         specifier: 3.1.0
         version: 3.1.0(assert@2.1.0)
       '@1inch/fusion-sdk':
-        specifier: 2.1.12-rc.1
-        version: 2.1.12-rc.1(assert@2.1.0)(axios@1.16.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+        specifier: 2.1.13-rc.0
+        version: 2.1.13-rc.0(assert@2.1.0)(axios@1.16.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@1inch/limit-order-sdk':
         specifier: 5.3.1
         version: 5.3.1(assert@2.1.0)(axios@1.16.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -209,8 +208,8 @@ packages:
       prettier: ^3.3.2
       typescript: ^5.5.2
 
-  '@1inch/fusion-sdk@2.1.12-rc.1':
-    resolution: {integrity: sha512-giFA1Ts447G9uAA9ze2tX5czz/orYLiYSANnw2VMUpwqRJF9faPHH8rAlqqMs65wZT92iztfPus8hgRa9V8UiQ==}
+  '@1inch/fusion-sdk@2.1.13-rc.0':
+    resolution: {integrity: sha512-FfX85CaSeDID08fpV3aGNZlYoSTS2QR1JGRXnjCI1Kp1DAo6tuCQoEJB9EJTYmsOnNYZPT+KgK1EdU9fdkd9HA==}
     peerDependencies:
       assert: ^2.0.0
       axios: '>=1 <2'
@@ -3621,7 +3620,7 @@ snapshots:
       semver: 7.7.4
       typescript: 5.9.3
 
-  '@1inch/fusion-sdk@2.1.12-rc.1(assert@2.1.0)(axios@1.16.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+  '@1inch/fusion-sdk@2.1.13-rc.0(assert@2.1.0)(axios@1.16.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
     dependencies:
       '@1inch/byte-utils': 3.1.0(assert@2.1.0)
       '@1inch/limit-order-sdk': 5.3.1(assert@2.1.0)(axios@1.16.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)

--- a/src/cross-chain-order/evm/evm-cross-chain-order.spec.ts
+++ b/src/cross-chain-order/evm/evm-cross-chain-order.spec.ts
@@ -1,4 +1,8 @@
-import {Extension, Address as FusionAddress} from '@1inch/fusion-sdk'
+import {
+    Extension,
+    Address as FusionAddress,
+    CHAIN_TO_WRAPPER
+} from '@1inch/fusion-sdk'
 import {ProxyFactory} from '@1inch/limit-order-sdk'
 import {UINT_256_MAX} from '@1inch/byte-utils'
 import {EvmCrossChainOrder} from './evm-cross-chain-order.js'
@@ -15,7 +19,6 @@ import {HashLock} from '../../domains/hash-lock/index.js'
 import {TimeLocks} from '../../domains/time-locks/index.js'
 import {getRandomBytes32} from '../../test-utils/get-random-bytes-32.js'
 import {NetworkEnum, EvmChain, SupportedChain} from '../../chains.js'
-import {CHAIN_TO_WRAPPER} from '../../deployments.js'
 
 describe('EvmCrossChainOrder', () => {
     it('Should encode/decode raw order', () => {

--- a/src/cross-chain-order/evm/evm-cross-chain-order.spec.ts
+++ b/src/cross-chain-order/evm/evm-cross-chain-order.spec.ts
@@ -194,6 +194,70 @@ describe('EvmCrossChainOrder', () => {
         ).toEqual(order)
     })
 
+    it('Should use chain specific limit order protocol as verifying contract', () => {
+        const factoryAddress = Address.fromBigInt(1n)
+        const orderData: EvmCrossChainOrderInfo = {
+            maker: Address.fromBigInt(2n),
+            makerAsset: EvmAddress.fromString(
+                '0xdac17f958d2ee523a2206206994597c13d831ec7'
+            ),
+            takerAsset: EvmAddress.fromString(
+                '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9'
+            ),
+            makingAmount: 100_000000n,
+            takingAmount: 90_000000n
+        }
+
+        const createOrder = (srcChainId: EvmChain): EvmCrossChainOrder =>
+            EvmCrossChainOrder.new(
+                factoryAddress,
+                orderData,
+                {
+                    hashLock: HashLock.forSingleFill(getRandomBytes32()),
+                    srcChainId,
+                    dstChainId: NetworkEnum.ARBITRUM,
+                    srcSafetyDeposit: 1000n,
+                    dstSafetyDeposit: 1000n,
+                    timeLocks: TimeLocks.new({
+                        srcWithdrawal: 1n,
+                        srcPublicWithdrawal: 2n,
+                        srcCancellation: 3n,
+                        srcPublicCancellation: 4n,
+                        dstWithdrawal: 1n,
+                        dstPublicWithdrawal: 2n,
+                        dstCancellation: 3n
+                    })
+                },
+                {
+                    auction: new AuctionDetails({
+                        startTime: BigInt(now()),
+                        duration: 180n,
+                        points: [],
+                        initialRateBump: 100_000
+                    }),
+                    whitelist: [
+                        {address: Address.fromBigInt(100n), allowFrom: 0n}
+                    ]
+                },
+                {
+                    nonce: 1n
+                }
+            )
+
+        // Robinhood chain has its own LOP deployment (non canonical address)
+        const robinhoodOrder = createOrder(NetworkEnum.ROBINHOOD)
+        expect(
+            robinhoodOrder.getTypedData(NetworkEnum.ROBINHOOD).domain
+                .verifyingContract
+        ).toEqual('0x5a705de8982235a7fa45bb83dcacf03a211389c7')
+
+        const ethereumOrder = createOrder(NetworkEnum.ETHEREUM)
+        expect(
+            ethereumOrder.getTypedData(NetworkEnum.ETHEREUM).domain
+                .verifyingContract
+        ).toEqual('0x111111125421ca6dc452d289314280a0f8842a65')
+    })
+
     it('should throw error for not supported chain', () => {
         const factoryAddress = Address.fromBigInt(1n)
         const orderData: EvmCrossChainOrderInfo = {

--- a/src/cross-chain-order/evm/evm-cross-chain-order.spec.ts
+++ b/src/cross-chain-order/evm/evm-cross-chain-order.spec.ts
@@ -1,8 +1,4 @@
-import {
-    Extension,
-    Address as FusionAddress,
-    CHAIN_TO_WRAPPER
-} from '@1inch/fusion-sdk'
+import {Extension, Address as FusionAddress} from '@1inch/fusion-sdk'
 import {ProxyFactory} from '@1inch/limit-order-sdk'
 import {UINT_256_MAX} from '@1inch/byte-utils'
 import {EvmCrossChainOrder} from './evm-cross-chain-order.js'
@@ -19,6 +15,7 @@ import {HashLock} from '../../domains/hash-lock/index.js'
 import {TimeLocks} from '../../domains/time-locks/index.js'
 import {getRandomBytes32} from '../../test-utils/get-random-bytes-32.js'
 import {NetworkEnum, EvmChain, SupportedChain} from '../../chains.js'
+import {CHAIN_TO_WRAPPER} from '../../deployments.js'
 
 describe('EvmCrossChainOrder', () => {
     it('Should encode/decode raw order', () => {
@@ -856,5 +853,86 @@ describe('EvmCrossChainOrder Native', () => {
             )
         )
         expect(order.dstChainId).toBe(NetworkEnum.SOLANA)
+    })
+
+    it('should create native order for Robinhood chain', () => {
+        const ethOrderFactory = new ProxyFactory(
+            FusionAddress.fromBigInt(1n),
+            FusionAddress.fromBigInt(2n)
+        )
+        const chainId = NetworkEnum.ROBINHOOD
+        const escrowFactory = EvmAddress.fromString(
+            '0xa02b9cc95094bb27d1d041b9fbf09f65a366f7b3'
+        )
+        const maker = EvmAddress.fromString(
+            '0x00000000219ab540356cbb839cbe05303d7705fa'
+        )
+        const takerAsset = EvmAddress.fromString(
+            '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9'
+        )
+
+        const orderInfo = {
+            takerAsset,
+            makingAmount: 1000000000000000000n,
+            takingAmount: 1420000000n,
+            maker
+        }
+
+        const details = {
+            auction: new AuctionDetails({
+                duration: 180n,
+                startTime: 1673548149n,
+                initialRateBump: 50000,
+                points: [
+                    {
+                        coefficient: 20000,
+                        delay: 12
+                    }
+                ]
+            }),
+            whitelist: [
+                {
+                    address: EvmAddress.fromString(
+                        '0x00000000219ab540356cbb839cbe05303d7705fa'
+                    ),
+                    allowFrom: 0n
+                }
+            ]
+        }
+
+        const escrowParams = {
+            hashLock: HashLock.forSingleFill(getRandomBytes32()),
+            srcChainId: NetworkEnum.ROBINHOOD as EvmChain,
+            dstChainId: NetworkEnum.ETHEREUM as EvmChain,
+            srcSafetyDeposit: 1000000000000000000n,
+            dstSafetyDeposit: 1000000000000000000n,
+            timeLocks: TimeLocks.new({
+                srcWithdrawal: 1n,
+                srcPublicWithdrawal: 2n,
+                srcCancellation: 3n,
+                srcPublicCancellation: 4n,
+                dstWithdrawal: 1n,
+                dstPublicWithdrawal: 2n,
+                dstCancellation: 3n
+            })
+        }
+
+        const order = EvmCrossChainOrder.fromNative(
+            chainId,
+            ethOrderFactory,
+            escrowFactory,
+            orderInfo,
+            details,
+            escrowParams
+        )
+
+        // WETH on Robinhood chain
+        expect(order.makerAsset.toString()).toBe(
+            '0x0bd7d308f8e1639fab988df18a8011f41eacad73'
+        )
+        expect(order.makerAsset.toString()).toBe(
+            CHAIN_TO_WRAPPER[chainId].toString()
+        )
+        expect(order.takerAsset.toString()).toBe(takerAsset.toString())
     })
 })

--- a/src/cross-chain-order/evm/evm-cross-chain-order.ts
+++ b/src/cross-chain-order/evm/evm-cross-chain-order.ts
@@ -1,5 +1,6 @@
 import {
     AuctionCalculator,
+    CHAIN_TO_WRAPPER,
     FusionOrder,
     EIP712TypedData,
     Extension,
@@ -28,7 +29,7 @@ import {
     EvmAddress
 } from '../../domains/addresses/index.js'
 import {BaseOrder} from '../base-order.js'
-import {CHAIN_TO_WRAPPER, TRUE_ERC20} from '../../deployments.js'
+import {TRUE_ERC20} from '../../deployments.js'
 import {
     EvmChain,
     isEvm,

--- a/src/cross-chain-order/evm/evm-cross-chain-order.ts
+++ b/src/cross-chain-order/evm/evm-cross-chain-order.ts
@@ -1,6 +1,5 @@
 import {
     AuctionCalculator,
-    CHAIN_TO_WRAPPER,
     FusionOrder,
     EIP712TypedData,
     Extension,
@@ -8,8 +7,7 @@ import {
     LimitOrderV4Struct,
     MakerTraits,
     SettlementPostInteractionData,
-    ZX,
-    NetworkEnum
+    ZX
 } from '@1inch/fusion-sdk'
 import {ProxyFactory} from '@1inch/limit-order-sdk'
 import assert from 'assert'
@@ -30,8 +28,13 @@ import {
     EvmAddress
 } from '../../domains/addresses/index.js'
 import {BaseOrder} from '../base-order.js'
-import {TRUE_ERC20} from '../../deployments.js'
-import {isEvm, isSupportedChain, SupportedChain} from '../../chains.js'
+import {CHAIN_TO_WRAPPER, TRUE_ERC20} from '../../deployments.js'
+import {
+    EvmChain,
+    isEvm,
+    isSupportedChain,
+    SupportedChain
+} from '../../chains.js'
 import {HashLock} from '../../domains/hash-lock/index.js'
 import {TimeLocks} from '../../domains/time-locks/index.js'
 import {bufferFromHex} from '../../utils/bytes.js'
@@ -254,7 +257,7 @@ export class EvmCrossChainOrder extends BaseOrder<
         const _orderInfo = {
             ...orderInfo,
             makerAsset: EvmAddress.fromString(
-                CHAIN_TO_WRAPPER[chainId as NetworkEnum].toString()
+                CHAIN_TO_WRAPPER[chainId as EvmChain].toString()
             ),
             receiver:
                 orderInfo.receiver && !orderInfo.receiver.isZero()

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -1,16 +1,5 @@
-import {
-    Address,
-    CHAIN_TO_WRAPPER as FUSION_CHAIN_TO_WRAPPER
-} from '@1inch/fusion-sdk'
-import {EvmChain, NetworkEnum} from './chains.js'
+import {NetworkEnum} from './chains.js'
 import {EvmAddress} from './domains/addresses/index.js'
-
-export const CHAIN_TO_WRAPPER: Record<EvmChain, Address> = {
-    ...FUSION_CHAIN_TO_WRAPPER,
-    [NetworkEnum.ROBINHOOD]: new Address(
-        '0x0bd7d308f8e1639fab988df18a8011f41eacad73'
-    )
-}
 
 const TrueERC20 = EvmAddress.fromString(
     '0xda0000d4000015a526378bb6fafc650cea5966f8'

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -1,5 +1,17 @@
-import {NetworkEnum} from './chains.js'
+import {
+    Address,
+    CHAIN_TO_WRAPPER as FUSION_CHAIN_TO_WRAPPER
+} from '@1inch/fusion-sdk'
+import {EvmChain, NetworkEnum} from './chains.js'
 import {EvmAddress} from './domains/addresses/index.js'
+
+// fusion-sdk@2.1.x lacks Robinhood chain in its CHAIN_TO_WRAPPER map
+export const CHAIN_TO_WRAPPER: Record<EvmChain, Address> = {
+    ...FUSION_CHAIN_TO_WRAPPER,
+    [NetworkEnum.ROBINHOOD]: new Address(
+        '0x0bd7d308f8e1639fab988df18a8011f41eacad73'
+    )
+}
 
 const TrueERC20 = EvmAddress.fromString(
     '0xda0000d4000015a526378bb6fafc650cea5966f8'

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -5,7 +5,6 @@ import {
 import {EvmChain, NetworkEnum} from './chains.js'
 import {EvmAddress} from './domains/addresses/index.js'
 
-// fusion-sdk@2.1.x lacks Robinhood chain in its CHAIN_TO_WRAPPER map
 export const CHAIN_TO_WRAPPER: Record<EvmChain, Address> = {
     ...FUSION_CHAIN_TO_WRAPPER,
     [NetworkEnum.ROBINHOOD]: new Address(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Two gaps in Robinhood Chain (4663) support on the v1 line:

1. **Wrong EIP-712 verifying contract.** `@1inch/limit-order-sdk@5.2.2` has no Robinhood entry in `getLimitOrderContract`, so `getTypedData` / `getOrderHash` fell through to the canonical router address `0x111111125421ca6dc452d289314280a0f8842a65`. However, the Robinhood escrow factory used by this SDK (`ESCROW_RH_FACTORY_ADDRESS = 0xa02b9cc95094bb27d1d041b9fbf09f65a366f7b3`, see `src/deployments.ts`) only trusts the Robinhood-specific `AggregationRouterV6` deployment at `0x5a705de8982235a7fa45bb83dcacf03a211389c7` — that address is embedded in the factory's deployed bytecode as its immutable limit-order-protocol reference (Robinhood Chain uses its own CREATE3 deployer, so 1inch contract addresses differ there). Verified on-chain: the contract's `eip712Domain()` returns `("1inch Aggregation Router", "6", 4663, 0x5a705de8982235a7fa45bB83dCaCf03a211389C7)`.

2. **Missing wrapped native token.** `@1inch/fusion-sdk@2.1.12-rc.1` has no chain 4663 entry in `CHAIN_TO_WRAPPER`, so `EvmCrossChainOrder.fromNative` threw a `TypeError` for Robinhood-source native orders.

## Fix

Robinhood support was backported to the fusion-sdk v2 line in 1inch/fusion-sdk#177 and released as `2.1.13-rc.0`, so both gaps are now fixed by plain dependency bumps:

- Bump `@1inch/fusion-sdk` from `2.1.12-rc.1` to `2.1.13-rc.0` — adds `ROBINHOOD` to `NetworkEnum` and `CHAIN_TO_WRAPPER` (WETH `0x0bd7d308f8e1639fab988df18a8011f41eacad73`, verified on-chain) and pins `limit-order-sdk@5.3.1` internally.
- Bump `@1inch/limit-order-sdk` from `5.2.2` to `5.3.1` — adds `ONE_INCH_LIMIT_ORDER_V4_ROBINHOOD = 0x5a705de8982235a7fa45bb83dcacf03a211389c7`, returned by `getLimitOrderContract(4663)` and used as the EIP-712 `verifyingContract`. pnpm resolves a single `5.3.1` instance for both the root and fusion-sdk.
- Add regression tests: typed-data `verifyingContract` is the Robinhood-specific router for chain 4663 (and canonical for Ethereum), and `fromNative` builds a Robinhood order with the correct WETH maker asset.

Earlier revisions of this PR worked around fusion-sdk pinning `limit-order-sdk@5.2.2` with a pnpm override plus a local `CHAIN_TO_WRAPPER` extension in `src/deployments.ts`; both workarounds were removed once `2.1.13-rc.0` shipped.

Note: fusion-sdk `2.4.x` (used on `master`) was evaluated and rejected for v1 — it carries the v2 order-model API (removed `SettlementPostInteractionData` export, changed `FusionExtension`, `SurplusParams` in constructors), producing 16 type errors in the v1 codebase.

Note: `limit-order-sdk@5.3.1` pins `ethers@6.16.0` for its own nested dependency; the SDK's direct `ethers@6.13.1` dependency is unchanged.

## Testing

- `pnpm build`, `pnpm lint:types`, `pnpm lint:ci` — clean (only pre-existing warnings)
- `pnpm test` — 21 suites, 122 passed / 1 skipped, including the new regression tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f374c6a-1646-4876-9a50-72bc86bd1457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f374c6a-1646-4876-9a50-72bc86bd1457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

